### PR TITLE
Fix react-markdown dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ npm run build
 ```bash
 npx webpack --config webpack.config.js
 ```
+Если при запуске webpack появится сообщение об отсутствии CLI, установите его
+командой:
+
+```bash
+npm install -D webpack-cli
+```
 
 В изолированной среде команда может закончиться ошибкой `403` из-за отсутствия доступа к registry.npmjs.org.
 

--- a/README_en.md
+++ b/README_en.md
@@ -49,6 +49,11 @@ You can also run webpack manually:
 ```bash
 npx webpack --config webpack.config.js
 ```
+If webpack prompts that the CLI is missing, install it with:
+
+```bash
+npm install -D webpack-cli
+```
 
 In an isolated environment the command may fail with `403` due to no access to registry.npmjs.org.
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "papaparse": "^5.4.1",
     "jspdf": "^3.0.1",
     "howler": "^2.2.4",
-    "react-markdown": "^8.1.0",
+    "react-markdown": "^8.0.7",
     "rehype-sanitize": "^5.0.1",
     "idb": "^8.0.3",
     "workbox-window": "^7.3.2",


### PR DESCRIPTION
## Summary
- correct `react-markdown` package version
- document how to install webpack CLI if missing

## Testing
- `npx webpack --config webpack.config.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/webpack)*

------
https://chatgpt.com/codex/tasks/task_e_685ec0bd6c1c8327a3bad61227f35dd3