### PR TITLE
Fix zustand imports

### DIFF
--- a/src/stores/combatStore.ts
+++ b/src/stores/combatStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 
 export interface Status {
   id: string;

--- a/src/stores/journalStore.ts
+++ b/src/stores/journalStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 
 export interface SessionNote {
   sessionId: string;

--- a/src/stores/mapStore.ts
+++ b/src/stores/mapStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Marker {

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { formatISO } from 'date-fns';
 
 export interface SessionEvent {

--- a/src/stores/useAudioStore.ts
+++ b/src/stores/useAudioStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Track {

--- a/src/stores/useAuthStore.ts
+++ b/src/stores/useAuthStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export type UserRole = 'admin' | 'user';

--- a/src/stores/useChatStore.ts
+++ b/src/stores/useChatStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export type ChatRole = 'NPC' | 'Player';

--- a/src/stores/useContentStore.ts
+++ b/src/stores/useContentStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { LOOT_TABLES, LootTableKey } from '../data/lootTables';
 import { EVENTS, EventCategory } from '../data/events';
 import {

--- a/src/stores/useFeatureFlagStore.ts
+++ b/src/stores/useFeatureFlagStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface FeatureFlags {

--- a/src/stores/useHotbarStore.ts
+++ b/src/stores/useHotbarStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export type MacroType = 'spell' | 'ability' | 'custom';

--- a/src/stores/useLogStore.ts
+++ b/src/stores/useLogStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export type LogLevel = 'info' | 'error';

--- a/src/stores/usePluginStore.ts
+++ b/src/stores/usePluginStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface PluginInfo {

--- a/src/stores/useTalentStore.ts
+++ b/src/stores/useTalentStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Talent {

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface ThemeSettingsState {

--- a/src/stores/useUsersStore.ts
+++ b/src/stores/useUsersStore.ts
@@ -1,4 +1,4 @@
-import create from 'zustand';
+import { create } from 'zustand';
 
 export interface AdminUser {
   id: string;


### PR DESCRIPTION
## Summary
- update zustand store imports to use named exports

## Testing
- `npx webpack --config webpack.config.js` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ed1c22f308327aade9bb2c2f2e853