### PR TITLE
Fix tsconfig and DataManager

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,1 @@
+declare const process: { env: Record<string, string | undefined> };

--- a/src/types/idb.d.ts
+++ b/src/types/idb.d.ts
@@ -1,0 +1,1 @@
+declare module 'idb';

--- a/src/utils/DataManager.ts
+++ b/src/utils/DataManager.ts
@@ -107,7 +107,7 @@ export class DataManager {
   }
 
   private async flushQueue() {
-    const ops = await getQueue();
+    const ops = await getQueue<{ key: string; data: unknown }>();
     for (const op of ops) {
       await setToDB(op.key, op.data);
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "esnext" /* Enable modern module syntax for features like import.meta. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./" /* Base directory for non-relative module names. */,


### PR DESCRIPTION
## Summary
- use `esnext` modules to enable import.meta
- type DataManager flushQueue operations
- add module stub for `idb` and global `process`

## Testing
- `npx webpack --config webpack.config.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685efcb57900832794b98c87be69fc0b