### PR TITLE
Fix React bootstrap null check

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,15 @@
 import React, { Suspense } from 'react';
-import ReactDOM from 'react-dom/client';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import './i18n';
 import App from './App';
 import { reportWebVitals } from './reportWebVitals';
 
-const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement,
-);
+const container = document.getElementById('root');
+if (!container) {
+  throw new Error('Root element not found');
+}
+const root = createRoot(container as HTMLElement);
 
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- ensure DOM container exists before calling `createRoot`

## Testing
- `npx webpack --config webpack.config.js` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68607c636a808327b71d6248ad766ffa