### PR TITLE
Fix data manager lifecycle

### DIFF
--- a/src/contexts/TalescribeContext.tsx
+++ b/src/contexts/TalescribeContext.tsx
@@ -88,7 +88,17 @@ export const TalescribeProvider: React.FC<TalescribeProviderProps> = ({
   const [items, setItems] = useState<Item[]>([]);
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
 
-  const dataManager = new DataManager();
+  const dataManagerRef = useRef<DataManager>();
+  if (!dataManagerRef.current) {
+    dataManagerRef.current = new DataManager();
+  }
+  const dataManager = dataManagerRef.current;
+
+  useEffect(() => {
+    return () => {
+      dataManager.destroy();
+    };
+  }, [dataManager]);
 
   useEffect(() => {
     loadData();


### PR DESCRIPTION
## Summary
- prevent `DataManager` from being recreated on every render
- clean up `DataManager` when provider unmounts

## Testing
- `npx webpack --config webpack.config.js` *(fails: needs webpack install)*

------
https://chatgpt.com/codex/tasks/task_e_68612778746c8327861a0c2177eff0ff