### PR TITLE
Fix imports and tsconfig

### DIFF
--- a/src/admin/AdminDashboard.tsx
+++ b/src/admin/AdminDashboard.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
+import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import AdminLayout from './AdminLayout';
 const UsersPage = React.lazy(() => import('./pages/UsersPage'));
 const CampaignsPage = React.lazy(() => import('./pages/CampaignsPage'));
@@ -7,7 +8,6 @@ const SessionsPage = React.lazy(() => import('./pages/SessionsPage'));
 const LogsPage = React.lazy(() => import('./pages/LogsPage'));
 const FlagsPage = React.lazy(() => import('./pages/FlagsPage'));
 const TranslationsPage = React.lazy(() => import('./pages/TranslationsPage'));
-import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 
 const AdminDashboard: React.FC = () => {
   return (

--- a/src/components/chat/MasterConsole.tsx
+++ b/src/components/chat/MasterConsole.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import ChatMessage from './ChatMessage';
+import { DragDropContext } from '@hello-pangea/dnd';
+import type { DropResult } from '@hello-pangea/dnd';
 import { useChat } from '../../stores/useChatStore';
-import { Hotbar, SpellList } from '../hotbar';
-import { DragDropContext, DropResult } from '@hello-pangea/dnd';
-import { downloadFile } from '../../utils/downloadFile';
 import { useHotbarStore } from '../../stores/useHotbarStore';
+import { Hotbar, SpellList } from '../hotbar';
+import { downloadFile } from '../../utils/downloadFile';
+import ChatMessage from './ChatMessage';
 
 const MasterConsole: React.FC = () => {
   const { messages, addMessage, clearChat, exportTranscript } = useChat();

--- a/src/components/combat/CombatTracker.tsx
+++ b/src/components/combat/CombatTracker.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import {
-  DragDropContext,
-  Droppable,
-  Draggable,
-  DropResult,
-} from '@hello-pangea/dnd';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import type { DropResult } from '@hello-pangea/dnd';
 import { useInitiative, useStatuses, Status } from '../../stores/combatStore';
 
 const TURN_TIME = 30;

--- a/src/pages/MapsPage.tsx
+++ b/src/pages/MapsPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapViewer from '../maps/MapViewer';
+import MapViewer from '../components/maps/MapViewer';
 
 const MapsPage: React.FC = () => (
   <div className="p-8 text-white">

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,4 +1,5 @@
-import { onCLS, onFID, onLCP, ReportHandler } from 'web-vitals';
+import { onCLS, onFID, onLCP } from 'web-vitals';
+import type { ReportHandler } from 'web-vitals';
 
 export function reportWebVitals(onPerfEntry?: ReportHandler) {
   if (onPerfEntry && onPerfEntry instanceof Function) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -118,5 +118,6 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/**/*", "src/i18n.d.ts"]
+  "files": ["src/i18n.d.ts"],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- fix import order in `AdminDashboard`
- split type imports for drag and drop
- fix MapViewer path
- tidy web vitals import
- include `src/i18n.d.ts` explicitly in tsconfig

## Testing
- `npx webpack --config webpack.config.js`
- `npx eslint src/admin/AdminDashboard.tsx src/components/chat/MasterConsole.tsx src/components/combat/CombatTracker.tsx src/pages/MapsPage.tsx src/reportWebVitals.ts`


------
https://chatgpt.com/codex/tasks/task_e_68614bc092e48327867e1cae99f6d580